### PR TITLE
Update cli.rs

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -961,7 +961,7 @@ mod panic_handler {
         fn stack(error: &Error) -> String;
     }
 
-    pub fn process(info: &std::panic::PanicInfo) -> String {
+    pub fn process(info: &std::panic::PanicHookInfo) -> String {
         let mut msg = info.to_string();
 
         // Add the error stack to our message.
@@ -998,7 +998,7 @@ mod panic_handler {
 impl WaglaylaCli {
     pub fn init_panic_hook(self: &Arc<Self>) {
         let this = self.clone();
-        let handler = move |info: &std::panic::PanicInfo| {
+        let handler = move |info: &std::panic::PanicHookInfo| {
             let msg = panic_handler::process(info);
             this.term().writeln(msg.crlf());
             panic_handler::console_error(msg);


### PR DESCRIPTION
Minor edit to - Line 1001 and 964, in Waglaylad-rusty-master/cli

warning: use of deprecated type alias `std::panic::PanicInfo`: use `PanicHookInfo` instead
    --> cli/src/cli.rs:1001:48
     |
1001 |         let handler = move |info: &std::panic::PanicInfo| {
     |                                                ^^^^^^^^^
     |
     = note: `#[warn(deprecated)]` on by default

warning: use of deprecated type alias `std::panic::PanicInfo`: use `PanicHookInfo` instead
   --> cli/src/cli.rs:964:39
    |
964 |     pub fn process(info: &std::panic::PanicInfo) -> String {
    |                                       ^^^^^^^^^

warning: `waglayla-cli` (lib) generated 2 warnings